### PR TITLE
Feature/SC-5289 Add "open in new tab" to tool configuration

### DIFF
--- a/controllers/tools.js
+++ b/controllers/tools.js
@@ -54,6 +54,7 @@ const sanitizeTool = (req, create=false) => {
   req.body.isLocal = (create ? !!req.body.isLocal : undefined);
   req.body.scope = req.body.scope || "openid offline";
   req.body.skipConsent = !!req.body.skipConsent;
+  req.body.openNewTab = !!req.body.openNewTab;
   return req;
 }
 

--- a/views/tools/forms/add-tool.hbs
+++ b/views/tools/forms/add-tool.hbs
@@ -21,6 +21,13 @@ Hinweis: Änderungen betreffen keine bereits instanzierten Tools in Kursen, ledi
     <input type="text" name="logo_url" id="logo_url" class="form-control" placeholder="">
 </div>
 <div class="form-group">
+    <label class="control-label">Direkt in neuem Tab öffnen?</label>
+    <label  style="width: 100%">
+        <input type="checkbox" name="openNewTab" value="1" class="form-control" style="width:10%;display:inline-block;">
+        Ja, direkt in neuem Tab öffnen
+    </label>
+</div>
+<div class="form-group">
     <label class="control-label" for="key">OAuth- bzw. LTI-ClientId</label>
     <input type="text" name="oAuthClientId" id="oAuthClientId" class="form-control" placeholder="">
 </div>


### PR DESCRIPTION
# Description
Tool configuration needs a new checkbox for a tool to be directly opened in a new tab.

## Links to Tickets or other pull requests
Requires: https://github.com/schul-cloud/schulcloud-server/pull/1475

## Changes
New configuration field in tool configuration.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
Not personal data.

## Deployment
Nothing required.

## New Repos, NPM pakages or vendor scripts
None

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/22246303/86135793-9221f000-baeb-11ea-97d6-857898bf4c0d.png)

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
