### PR TITLE
Feature/sc 6950 manage school kreis and official school number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Added
 
+- SC-6950 - Add Manage school kreis and officialSchoolNumber
 - OPS-1297 - Added Changelog github action
 - SC-7483 - Updating terms of use for all users for each instance separately
 - SC-8247 - Update SHD platform with new texts regarding consent upload (fix for modal naming)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-* node.js 6 or later (You can install it from https://nodejs.org/en/download/)
+* node.js 12 or later (You can install it from https://nodejs.org/en/download/)
 
 ## Setup
 

--- a/controllers/schools.js
+++ b/controllers/schools.js
@@ -95,6 +95,9 @@ const getDetailHandler = (service) => {
                 data[key] = data.features.indexOf(feature) !== -1;
             }
 
+        if (data.county && data.county.name) {
+          data.county = data.county._id;
+        }
             res.json(data);
         }).catch(err => {
             next(err);
@@ -163,12 +166,24 @@ const getHandler = async (req, res) => {
         baseUrl: `/schools/?p={{page}}${sortQuery}${limitQuery}${searchQuery}`
     };
 
+  // Extracts all counties from federalstates
+  const allCounties = federalStates.data
+    .map((state) => {
+      return state.counties.map((county) => {
+        if (county && county.name) {
+          return county;
+        }
+      });
+    })
+    .flat();
+
     res.render('schools/schools', {
         title: 'Schulen',
         head,
         body,
         pagination,
         federalState: federalStates.data,
+        county: allCounties,
         user: res.locals.currentUser,
         storageType: getStorageTypes(),
         timeZones: getTimezones(),

--- a/views/schools/forms/add-school.hbs
+++ b/views/schools/forms/add-school.hbs
@@ -11,6 +11,17 @@
     </select>
 </div>
 <div class="form-group">
+    <label class="control-label" for="county">Kreis</label>
+    <select name="county">
+        {{#each county}}
+            <option value="{{this._id}}">{{this.name}}</option>
+        {{/each}}   
+    </select>
+    <p class="text-danger" style="font-size:0.75rem;">
+        Warning: all counties/kreis from all states/bundesland are listed here
+    </p>
+</div>
+<div class="form-group">
     <label class="control-label" for="fileStorageType">File-Storage-Typ</label>
     <select name="fileStorageType" type="text">
         {{#each storageType}}
@@ -26,6 +37,14 @@
         {{/each}}
     </select>
 </div>
+<div class="form-group">
+    <label class="control-label" for="officialSchoolNumber">Official School Number</label>
+        <input type="text" name="officialSchoolNumber" id="officialSchoolNumber" class="form-control" >
+    <p class="text-danger" style="font-size:0.75rem;">
+        Allowed format: AB-12345 <em>OR</em> 12345
+    </p>
+</div>
+
 <div class="form-group">
     <label class="control-label" for="timezone">Time zone</label>
     <select name="timezone" type="text">


### PR DESCRIPTION
https://ticketsystem.hpi-schul-cloud.org/browse/SC-6950

[Server pr](https://github.com/hpi-schul-cloud/schulcloud-server/pull/2187)
[SHD pr](https://github.com/hpi-schul-cloud/superhero-dashboard/pull/105)

This ticket allows super heroes to change 'officialSchoolNumber' and 'county' in the school-document.
See video in [ticket](https://ticketsystem.hpi-schul-cloud.org/browse/SC-6950)