### PR TITLE
OPS-2574 - Removeing autodeployed branches for developers if branch deleted

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,17 @@
+---
+name: Clean Deployment
+
+on: delete
+
+jobs:
+  dispatch-clean:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: hpi-schul-cloud/dof_app_deploy
+          event-type: dev-clean
+          client-payload: '{"branch": "${{ github.event.ref }}" }'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ## [Unreleased]
 
 - SC-9142 and SC-9170 - fix deletion of users
+- OPS-2574 - Removeing autodeployed branches for developers if branch deleted
 
 ## [26.2.1] - 2021-06-25
 


### PR DESCRIPTION
# Description
OPS-2574 - Removeing autodeployed branches for developers if branch deleted

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2574

## Changes

Removeing autodeployed branches for developers if branch deleted

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

## Deployment


## New Repos, NPM pakages or vendor scripts


## Screenshots of UI changes

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
