### PR TITLE
BC-331 - BC-351 - rename ansible variables for OnePassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
+ - BC-331 - BC-351 - rename ansible variables for OnePassword
+
 ## [26.10.0] - 2021-09-03
 
 ### Changed

--- a/ansible/roles/superhero-dashboard/tasks/main.yml
+++ b/ansible/roles/superhero-dashboard/tasks/main.yml
@@ -15,14 +15,14 @@
       kubeconfig: ~/.kube/config 
       namespace: "{{ NAMESPACE }}"
       template: secret.yml.j2
-    when: ONEPASSWORD is undefined or ONEPASSWORD is defined and not ONEPASSWORD
+    when: ONEPASSWORD_OPERATOR is undefined or ONEPASSWORD_OPERATOR is defined and not ONEPASSWORD_OPERATOR
       
   - name: Secred by 1Password
     community.kubernetes.k8s:
       kubeconfig: ~/.kube/config 
       namespace: "{{ NAMESPACE }}"
       template: onepassword.yml.j2
-    when: ONEPASSWORD is defined and ONEPASSWORD|bool
+    when: ONEPASSWORD_OPERATOR is defined and ONEPASSWORD_OPERATOR|bool
       
   - name: Deployment
     community.kubernetes.k8s:

--- a/ansible/roles/superhero-dashboard/templates/onepassword.yml.j2
+++ b/ansible/roles/superhero-dashboard/templates/onepassword.yml.j2
@@ -6,4 +6,4 @@ metadata:
   labels:
     app: shd
 spec:
-  itemPath: "vaults/{{ VAULT }}/items/shd"
+  itemPath: "vaults/{{ ONEPASSWORD_OPERATOR_VAULT }}/items/shd"


### PR DESCRIPTION
# Description
Rename ansible variables for OnePassword

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-331
https://ticketsystem.hpi-schul-cloud.org/browse/BC-351

## Changes
Rename ansible variables for OnePassword

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
