### PR TITLE
BC-1302 - move the settings form reference to all, will be overwritten for develop

### DIFF
--- a/ansible/group_vars/all/superhero-dashboard.yml
+++ b/ansible/group_vars/all/superhero-dashboard.yml
@@ -1,2 +1,4 @@
 ---
 SHD_PORT: 3033
+SUPERHERO_DASHBOARD_IMAGE: schulcloud/superhero-dashboard
+SHD_PREFIX: dashboard.

--- a/ansible/group_vars/reference/superhero-dashboard.yml
+++ b/ansible/group_vars/reference/superhero-dashboard.yml
@@ -1,3 +1,0 @@
----
-SUPERHERO_DASHBOARD_IMAGE: schulcloud/superhero-dashboard
-SHD_PREFIX: dashboard.


### PR DESCRIPTION
# Description
Set the ansible variabel SUPERHERO_DASHBOARD_IMAGE will be set default to the schulcloud/schulcloud-dashboard as docker regestry.
Also set the ansible variabel SHD_PREFIX to dashboard. as default .
It will be overwritten by the value from ansible/group_vars/develop/schulcloud-server.yml for the develop instances

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-server#3321
hpi-schul-cloud/schulcloud-client#2767
hpi-schul-cloud/nuxt-client#2051
hpi-schul-cloud/schulcloud-calendar#112
hpi-schul-cloud/antivirus_check_service#22
https://ticketsystem.hpi-schul-cloud.org/browse/BC-1302

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.