### PR TITLE
BC-5100 - pin docker/build-push-action to version 4.1.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build and push ${{ github.repository }}
         if: ${{ env.IMAGE_EXISTS == 0 }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -46,7 +46,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push ${{ github.repository }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
# Description
the current version 4.2.0 for the github action docker/build-push-action who is pulled if we use as version set v4 hass an issue with our metadata json so we must pin it to version 4.1.1 for now

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-5100
hpi-schul-cloud/antivirus_check_service#41
hpi-schul-cloud/version-aggregator#10
hpi-schul-cloud/h5p-staticfiles-server#3
hpi-schul-cloud/schulcloud-server#4396
hpi-schul-cloud/schulcloud-client#3299
hpi-schul-cloud/nuxt-client#2795
hpi-schul-cloud/schulcloud-calendar#141

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
